### PR TITLE
Simpler search return format

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,18 +33,38 @@ def test_optimal_search_path(search_fn):
 
 @pytest.mark.parametrize('search_fn', HEURISTIC_SEARCH_FUNCS)
 @pytest.mark.parametrize('target_node', OPTIMAL_COSTS_FROM_ARAD.keys())
-def test_optimal_search_costs(search_fn, target_node):
+def test_optimal_search_target_node(search_fn, target_node):
     start_node = 'Arad'
     goal_fn = lambda x: x == target_node
 
-    goal, path_costs = search_fn(
+    # Do not use heuristic here, since it shows distance to Bucharest.
+    goal, cost = search_fn(
         start_node=start_node,
-        heuristic_fn=heuristic_fn,
         expand_fn=expand_fn,
         goal_fn=goal_fn,
         return_path=False
     )
 
+    assert goal == target_node
+    assert cost == OPTIMAL_COSTS_FROM_ARAD[goal]
+
+
+@pytest.mark.parametrize('search_fn', HEURISTIC_SEARCH_FUNCS)
+@pytest.mark.parametrize('target_node', OPTIMAL_COSTS_FROM_ARAD.keys())
+def test_optimal_search_costs(search_fn, target_node):
+    start_node = 'Arad'
+    goal_fn = lambda x: x == target_node
+
+    # Do not use heuristic here, since it shows distance to Bucharest.
+    goal, path_costs, optimal_path = search_fn(
+        start_node=start_node,
+        expand_fn=expand_fn,
+        goal_fn=goal_fn,
+        return_path=True
+    )
+
     for node, cost in path_costs.items():
         if node in optimal_path:
             assert cost == OPTIMAL_COSTS_FROM_ARAD[node]
+
+

--- a/trickster/search.py
+++ b/trickster/search.py
@@ -20,8 +20,9 @@ def a_star_search(start_node, expand_fn, goal_fn,
     '''
     A* search.
 
-    Return the target node, the costs of nodes expanded by the algorithm,
-    and the optimal path from the initial node to the target node.
+    Returns the tuple (cost, target_node) if return_path is set to False.
+    Otherwise, returns the target node, the costs of nodes expanded by the
+    algorithm, and the optimal path from the initial node to the target node.
 
     :param start_node: Initial node.
     :param expand_fn: Returns an iterable of tuples (neighbour, cost).
@@ -67,7 +68,8 @@ def a_star_search(start_node, expand_fn, goal_fn,
                 optimal_path = _get_optimal_path(
                         predecessors, start_node, node)
                 return node, path_costs, optimal_path
-            return node, path_costs
+            else:
+                return (node, path_costs[hashed_node])
         closed_set.add(hashed_node)
 
         # Iterate through all neighbours of the current node
@@ -97,4 +99,6 @@ def a_star_search(start_node, expand_fn, goal_fn,
     # Goal node is unreachable.
     if return_path:
         return None, path_costs, None
-    return None, path_costs
+    else:
+        return None, None
+


### PR DESCRIPTION
* Return `(goal, score)` when `return_path` is `False`.
* Don't use distance to Bucharest heuristic in searches whose target node is not Bucharest